### PR TITLE
Enable the UTF8 codepage by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "epson"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "image",
  "tokio",

--- a/src/async_tokio.rs
+++ b/src/async_tokio.rs
@@ -74,7 +74,8 @@ impl AsyncWriter {
 
     /// initialize the epson printer
     async fn init(&mut self) -> Result<()> {
-        self.write_command(Command::Init).await
+        self.write_command(Command::Init).await?;
+        self.write_command(Command::SetUtf8).await
     }
 
     /// cut the printer paper

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -68,6 +68,9 @@ pub enum Command {
     /// Feed the specified number of lines.
     Feed(u8),
 
+    /// Switch the active encoding to be UTF-8.
+    SetUtf8,
+
     /// Print a greyscale image
     Image(image::ImageBuffer<image::Luma<u8>, Vec<u8>>),
 }
@@ -85,6 +88,7 @@ impl Command {
             Command::Justification(alignment) => vec![0x1b, b'a', *alignment as u8],
             Command::Feed(count) => vec![0x1b, b'd', *count],
             Command::Speed(speed) => vec![0x1d, 0x28, 0x4b, 0x02, 0x00, 0x32, speed % 9],
+            Command::SetUtf8 => vec![0x1C, 0x28, 0x43, 0x02, 0x00, 0x30, 0x2],
             Command::Image(img) => {
                 let buf: ImageBuffer = (img.clone()).try_into()?;
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -70,7 +70,8 @@ impl Writer {
 
     /// initialize the epson printer
     fn init(&mut self) -> Result<()> {
-        self.write_command(Command::Init)
+        self.write_command(Command::Init)?;
+        self.write_command(Command::SetUtf8)
     }
 
     /// cut the printer paper


### PR DESCRIPTION
See:
- https://stackoverflow.com/questions/63546719/esc-pos-termal-printer-utf-8-charset-set-up
- https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=337